### PR TITLE
:lipstick: fix help-text icon layout in the admin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "referentielijsten",
-  "version": "1.0.0-alpha.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "referentielijsten",
-      "version": "1.0.0-alpha.0",
-      "license": "UNLICENSED",
+      "version": "0.1.0",
+      "license": "EUPL",
       "dependencies": {
         "microscope-sass": "latest"
       },

--- a/src/referentielijsten/scss/admin/_admin_theme.scss
+++ b/src/referentielijsten/scss/admin/_admin_theme.scss
@@ -175,7 +175,53 @@ div.breadcrumbs {
 /**
  * Help text mouseover
  */
- div.help {
+div.help {
+  cursor: help;
+  block-size: 14px;
+  inline-size: 14px;
+
+  background-image: url(../admin/img/icon-unknown.svg);
+  background-repeat: no-repeat;
+  background-size: 14px;
+  margin-left: 8px !important;
+  margin-top: 6px !important;
+  padding-inline: 0 !important;
+  padding-block: 0 !important;
+
+  position: relative; // provides an anchor for the nested div absolute positioning
+
+  // the actual content is nested in a div, so we can easily hide it by default
+  > div {
+    display: none;
+  }
+
+  // On hover of the icon, we display the real help text content.
+  &:hover {
+    background-image: none;
+
+    > div {
+      display: block;
+      position: absolute;
+      top: 1px;
+      z-index: 10;
+
+      block-size: auto;
+      inline-size: max-content;
+      max-inline-size: 300px;
+      padding-block: 5px 3px;
+      padding-inline: 5px 5px;
+
+      background-color: $color-tooltip-background;
+      border: 1px solid $color-tooltip-border;
+      color: $color-tooltip-text;
+    }
+  }
+}
+
+/**
+ * Help text for datetime field is without inner div
+ */
+div.help:not(:has(div)) {
   cursor: help;
   width: 16px;
   height: 16px;
@@ -185,7 +231,7 @@ div.breadcrumbs {
   background-size: 14px;
   margin-left: 8px !important;
   margin-top: 6px !important;
-  position: relative;
+  position: absolute;
   text-indent: -9999px;
 
   &:hover {
@@ -202,6 +248,19 @@ div.breadcrumbs {
     z-index: 10;
   }
 }
+
+
+/**
+ * Help text layout
+ */
+.form-row:has(.help) {
+  overflow: visible;
+}
+
+div:has(> div.help ) {
+  display: flex;
+}
+
 
 .related-widget-wrapper ~ div.help {
   margin-top: 8px !important;


### PR DESCRIPTION
Fixes https://github.com/open-zaak/open-notificaties/issues/150 (Referentielijsten part)


