### PR TITLE
:bug: [#41] Order API endpoints by pk (descending)

### DIFF
--- a/src/referentielijsten/api/tests/test_items.py
+++ b/src/referentielijsten/api/tests/test_items.py
@@ -42,9 +42,9 @@ class ItemsApiTests(APITestCase):
         self.assertEqual(response_data["count"], 3)
         results = response_data["results"]
 
-        self.assertEqual(results[0]["code"], item1.code)
+        self.assertEqual(results[0]["code"], item3.code)
         self.assertEqual(results[1]["code"], item2.code)
-        self.assertEqual(results[2]["code"], item3.code)
+        self.assertEqual(results[2]["code"], item1.code)
 
     def test_items_with_none_existing_tabel_code(self):
         TabelFactory.create(code="123")
@@ -101,10 +101,10 @@ class ItemsApiTests(APITestCase):
         self.assertEqual(response_data["count"], 4)
         results = response_data["results"]
 
-        self.assertEqual(results[0]["code"], "1")
-        self.assertEqual(results[1]["code"], "2")
-        self.assertEqual(results[2]["code"], "3")
-        self.assertEqual(results[3]["code"], "4")
+        self.assertEqual(results[0]["code"], "4")
+        self.assertEqual(results[1]["code"], "3")
+        self.assertEqual(results[2]["code"], "2")
+        self.assertEqual(results[3]["code"], "1")
 
         response = self.client.get(
             self.url, {"tabel__code": "123", "isGeldig": "false"}
@@ -115,5 +115,5 @@ class ItemsApiTests(APITestCase):
         self.assertEqual(response_data["count"], 2)
         results = response_data["results"]
 
-        self.assertEqual(results[0]["code"], "5")
-        self.assertEqual(results[1]["code"], "6")
+        self.assertEqual(results[0]["code"], "6")
+        self.assertEqual(results[1]["code"], "5")

--- a/src/referentielijsten/api/viewset.py
+++ b/src/referentielijsten/api/viewset.py
@@ -40,7 +40,7 @@ from .serializers import ItemSerializer, TabelSerializer
     )
 )
 class ItemViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
-    queryset = Item.objects.all()
+    queryset = Item.objects.order_by("-pk")
     serializer_class = ItemSerializer
     filterset_class = ItemFilterset
 
@@ -55,6 +55,6 @@ class ItemViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     ),
 )
 class TabelViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
-    queryset = Tabel.objects.all()
+    queryset = Tabel.objects.order_by("-pk")
     serializer_class = TabelSerializer
     filterset_class = TabelFilterset


### PR DESCRIPTION
previously there was no explicit ordering, which raised warnings

Fixes #41 

**Changes**

* Order API endpoints by pk (descending)

