### PR TITLE
:sparkles: [#70] allow to select a table for importing

### DIFF
--- a/src/referentielijsten/api/admin.py
+++ b/src/referentielijsten/api/admin.py
@@ -9,12 +9,21 @@ from referentielijsten.utils.admin import filter_title
 
 from .admin_list_filters import GeldigListFilter
 from .models import Item, Tabel
+from .forms import ItemImportForm, ItemConfirmImportForm
 
 
 class ItemResource(resources.ModelResource):
+    def __init__(self, *args, selected_tabel=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.selected_tabel = selected_tabel
+
+    def before_import_row(self, row, **kwargs):
+        if self.selected_tabel:
+            row["tabel"] = self.selected_tabel.id
 
     class Meta:
         model = Item
+        import_id_fields = ("code",)
 
 
 @admin.register(Item)
@@ -32,7 +41,8 @@ class ItemAdmin(ImportExportModelAdmin):
         "einddatum_geldigheid",
         "aanvullende_gegevens",
     )
-
+    import_form_class = ItemImportForm
+    confirm_form_class = ItemConfirmImportForm
     resource_classes = [ItemResource]
 
     @admin.display(description=_("Is geldig"), boolean=True)
@@ -45,6 +55,18 @@ class ItemAdmin(ImportExportModelAdmin):
             return True
 
         return False
+
+    def get_confirm_form_initial(self, request, import_form):
+        initial = super().get_confirm_form_initial(request, import_form)
+        if import_form and import_form.is_valid():
+            initial["selected_tabel"] = import_form.cleaned_data.get("selected_tabel")
+        return initial
+
+    def get_import_resource_kwargs(self, request, form=None):
+        resource_kwargs = super().get_import_resource_kwargs(request, form=form)
+        if form and form.is_valid():
+            resource_kwargs["selected_tabel"] = form.cleaned_data.get("selected_tabel")
+        return resource_kwargs
 
 
 @admin.register(Tabel)

--- a/src/referentielijsten/api/admin.py
+++ b/src/referentielijsten/api/admin.py
@@ -8,8 +8,8 @@ from import_export.admin import ImportExportModelAdmin
 from referentielijsten.utils.admin import filter_title
 
 from .admin_list_filters import GeldigListFilter
+from .forms import ItemConfirmImportForm, ItemImportForm
 from .models import Item, Tabel
-from .forms import ItemImportForm, ItemConfirmImportForm
 
 
 class ItemResource(resources.ModelResource):

--- a/src/referentielijsten/api/forms.py
+++ b/src/referentielijsten/api/forms.py
@@ -1,5 +1,7 @@
-from import_export.forms import ImportForm, ConfirmImportForm
 from django import forms
+
+from import_export.forms import ConfirmImportForm, ImportForm
+
 from .models import Tabel
 
 

--- a/src/referentielijsten/api/forms.py
+++ b/src/referentielijsten/api/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from import_export.forms import ConfirmImportForm, ImportForm
 
@@ -10,12 +11,16 @@ class ItemImportForm(ImportForm):
         queryset=Tabel.objects.all(),
         label="Tabel",
         required=False,
-        help_text="Selecteer een tabel om toe te passen op alle geïmporteerde items, "
-        "tenzij de tabel al is aangegeven in het bestand.",
+        help_text=_(
+            "Selecteer een tabel voor alle geïmporteerde items. "
+            "Als je hier een tabel selecteert, wordt een eventuele 'table_id' in het bestand genegeerd."
+        ),
     )
 
 
 class ItemConfirmImportForm(ConfirmImportForm):
     selected_tabel = forms.ModelChoiceField(
-        queryset=Tabel.objects.all(), label="Tabel", required=False
+        queryset=Tabel.objects.all(),
+        required=False,
+        widget=forms.HiddenInput(),
     )

--- a/src/referentielijsten/api/forms.py
+++ b/src/referentielijsten/api/forms.py
@@ -1,0 +1,19 @@
+from import_export.forms import ImportForm, ConfirmImportForm
+from django import forms
+from .models import Tabel
+
+
+class ItemImportForm(ImportForm):
+    selected_tabel = forms.ModelChoiceField(
+        queryset=Tabel.objects.all(),
+        label="Tabel",
+        required=False,
+        help_text="Selecteer een tabel om toe te passen op alle geïmporteerde items, "
+        "tenzij de tabel al is aangegeven in het bestand.",
+    )
+
+
+class ItemConfirmImportForm(ConfirmImportForm):
+    selected_tabel = forms.ModelChoiceField(
+        queryset=Tabel.objects.all(), label="Tabel", required=False
+    )

--- a/src/referentielijsten/api/tests/test_import.py
+++ b/src/referentielijsten/api/tests/test_import.py
@@ -1,0 +1,55 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from import_export.formats.base_formats import CSV
+
+from ..admin import ItemAdmin, ItemResource, admin
+from ..forms import ItemImportForm
+from ..models import Item
+from .factories import TabelFactory
+
+
+class ItemAdminTests(TestCase):
+    def get_test_form(self, form_data):
+        dummy_file = SimpleUploadedFile("test.csv", b"code,naam\n123,Test Item\n")
+        dummy_file.tmp_storage_name = "test.csv"
+
+        form_data["format"] = "0"
+        form = ItemImportForm(
+            [CSV],
+            [ItemResource],
+            data=form_data,
+            files={"import_file": dummy_file},
+        )
+        return form
+
+    def test_get_confirm_form_initial(self):
+        tabel = TabelFactory.create(code="123")
+        form = self.get_test_form({"selected_tabel": tabel.pk})
+        self.assertTrue(form.is_valid(), form.errors)
+
+        item_admin = ItemAdmin(Item, admin.site)
+        initial_data = item_admin.get_confirm_form_initial(self.client, form)
+
+        self.assertEqual(initial_data["selected_tabel"], tabel)
+
+    def test_get_import_resource_kwargs(self):
+        tabel = TabelFactory.create(code="123")
+
+        form = self.get_test_form({"selected_tabel": tabel.pk})
+        self.assertTrue(form.is_valid(), form.errors)
+
+        item_admin = ItemAdmin(Item, admin.site)
+        resource_kwargs = item_admin.get_import_resource_kwargs(self.client, form=form)
+
+        self.assertEqual(resource_kwargs["selected_tabel"], tabel)
+
+    def test_before_import_row_sets_tabel_id(self):
+        tabel = TabelFactory.create(code="123")
+
+        resource = ItemResource(selected_tabel=tabel)
+        row = {"code": "123", "naam": "Test Item"}
+
+        resource.before_import_row(row)
+
+        self.assertEqual(row["tabel"], tabel.id)


### PR DESCRIPTION
Fixes #70 

**Changes**
When importing items, you can now select a table to add the items to it (only code and naam are required).
If the CSV or Excel file already contains table information, you won't need to manually select a table.
