### PR TITLE
:arrow_up: [maykinmedia/commonground-api-common#134] Upgrade commonground-api-common to ensure API errors are sent to Sentry

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -55,7 +55,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
-commonground-api-common==2.10.1
+commonground-api-common==2.10.5
     # via open-api-framework
 cryptography==44.0.1
     # via
@@ -326,7 +326,9 @@ ruamel-yaml-clib==0.2.12
 semantic-version==2.10.0
     # via django-upgrade-check
 sentry-sdk==2.13.0
-    # via open-api-framework
+    # via
+    #   commonground-api-common
+    #   open-api-framework
 six==1.16.0
     # via
     #   bleach

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -111,7 +111,7 @@ click-repl==0.3.0
     #   celery
 codecov==2.1.13
     # via -r requirements/test-tools.in
-commonground-api-common==2.10.1
+commonground-api-common==2.10.5
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -658,6 +658,7 @@ sentry-sdk==2.13.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   commonground-api-common
     #   open-api-framework
 six==1.16.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -136,7 +136,7 @@ codecov==2.1.13
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-commonground-api-common==2.10.1
+commonground-api-common==2.10.5
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -785,6 +785,7 @@ sentry-sdk==2.13.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   commonground-api-common
     #   open-api-framework
 setuptools==80.8.0
     # via pip-tools


### PR DESCRIPTION
Fixes maykinmedia/commonground-api-common#134 partially

**Changes**

* Upgrade commonground-api-common to ensure API errors are sent to Sentry

