### PR TITLE
:green_heart: Only specify build for web container in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 
   web:
     build: .
-    image: maykinmedia/referentielijsten-api:latest
+    image: maykinmedia/referentielijsten-api:${TAG:-latest}
     environment: &app-env
       DJANGO_SETTINGS_MODULE: referentielijsten.conf.docker
       SECRET_KEY: ${SECRET_KEY:-django-insecure-4foe-_dk9x=88*0sljyo1_ga!!nj*x8ye6u0p(@871e)zg^+q}
@@ -61,7 +61,7 @@ services:
       - referentielijsten-dev
 
   web-init:
-    build: .
+    image: maykinmedia/referentielijsten-api:${TAG:-latest}
     environment:
       <<: *app-env
       #


### PR DESCRIPTION
this should fix issues in CI where containers that use the same image as web cause cannot be tagged due to duplicate images names

