### PR TITLE
:memo: [maykinmedia/open-api-framework#205] Slight changes to versioning policy

### DIFF
--- a/docs/introduction/versioning.rst
+++ b/docs/introduction/versioning.rst
@@ -7,11 +7,16 @@ New version releases for Referentielijsten API are done every two months, at the
 Major releases occur every two years.
 
 Each major version is supported until 24 months after the release of the next major version.
-The most recent major version is supported without a fixed end date until a new major version is released.
-Each minor version within a supported major version is supported until 6 months after its release.
+The most recent major version is supported without a fixed end date until a new major version is released
+and is the only major version for which new minor versions can be released.
+Within each supported major version, only the two most recent minor versions are supported
+at any given time, with the oldest of these two only being supported at most 6 months after its release.
 
 Only the latest version (the numbered version, not the technical latest-tag)
-is actively maintained and under active development. Older versions only receive patches
+is actively maintained and under active development. Older versions only receive patches.
+
+The table below shows each major and minor version and until what date they can receive
+patches.
 
 .. note::
 


### PR DESCRIPTION
Fixes maykinmedia/open-api-framework#205

**Changes**

* Support at most two minor versions at a time for each major version
* More clearly state that older major versions do not get new minor versions anymore