### PR TITLE
:construction_worker: Disable OAS lint job due to vulnerability

### DIFF
--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -1,32 +1,32 @@
-name: OAS
+# name: OAS
 
-on:
-  push:
-    branches:
-      - master
-      - stable/*
-    tags:
-      - '*'
-  pull_request:
-  workflow_dispatch:
+# on:
+#   push:
+#     branches:
+#       - master
+#       - stable/*
+#     tags:
+#       - '*'
+#   pull_request:
+#   workflow_dispatch:
 
-# least privilege as default, should be overridden per job if necessary
-permissions:
-  contents: read
+# # least privilege as default, should be overridden per job if necessary
+# permissions:
+#   contents: read
 
-jobs:
-  oas:
-    name: Checks
-    uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
-    with:
-      python-version: '3.12'
-      django-settings-module: referentielijsten.conf.ci
-      oas-generate-command: ./bin/generate_schema.sh
-      schema-path: src/referentielijsten/api/openapi.yaml
-      oas-artifact-name: referentielijsten-api-oas
-      node-version-file: '.nvmrc'
-      spectral-version: '^6.15.0'
-      openapi-to-postman-version: '^5.0.0'
-      postman-artifact-name: referentielijsten-api-postman-collection
-      openapi-generator-version: '^2.20.0'
-      spectral-ruleset: ruleset.yaml
+# jobs:
+#   oas:
+#     name: Checks
+#     uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+#     with:
+#       python-version: '3.12'
+#       django-settings-module: referentielijsten.conf.ci
+#       oas-generate-command: ./bin/generate_schema.sh
+#       schema-path: src/referentielijsten/api/openapi.yaml
+#       oas-artifact-name: referentielijsten-api-oas
+#       node-version-file: '.nvmrc'
+#       spectral-version: '^6.15.0'
+#       openapi-to-postman-version: '^5.0.0'
+#       postman-artifact-name: referentielijsten-api-postman-collection
+#       openapi-generator-version: '^2.20.0'
+#       spectral-ruleset: ruleset.yaml


### PR DESCRIPTION
asyncapi/specs was compromised and spectral installs this, not pinned to a specific version

Fixes #

**Changes**

[Describe the changes here]

**Checklist**

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [ ] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/maykinmedia/referentielijsten/wiki/Architectural-Decision-Records-(ADR))
